### PR TITLE
Added optional argument to Bot to configure behaviour of default command set

### DIFF
--- a/src/diggler/bot.d
+++ b/src/diggler/bot.d
@@ -148,6 +148,13 @@ final class Bot
 		deprecated alias nick = nickName;
 	}
 
+	enum HelpCommand
+	{
+		none,
+		simple,
+		categorical
+	}
+
 	/**
 	 * Create a new bot with the given configuration.
 	 *
@@ -155,14 +162,14 @@ final class Bot
 	 * by the given event loop. Otherwise, the bot shares a default
 	 * event loop with all other bots created in the same thread.
 	 */
-	this(Configuration conf, string file = __FILE__, size_t line = __LINE__)
+	this(Configuration conf, HelpCommand help = HelpCommand.categorical, string file = __FILE__, size_t line = __LINE__)
 	{
 		import diggler.eventloop : defaultEventLoop;
-		this(conf, defaultEventLoop, file, line);
+		this(conf, defaultEventLoop, help, file, line);
 	}
 
 	/// Ditto
-	this(Configuration conf, IrcEventLoop eventLoop, string file = __FILE__, size_t line = __LINE__)
+	this(Configuration conf, IrcEventLoop eventLoop, HelpCommand help = HelpCommand.categorical, string file = __FILE__, size_t line = __LINE__)
 	{
 		this._eventLoop = eventLoop;
 
@@ -173,7 +180,8 @@ final class Bot
 
 		this._commandQueue = new CommandQueue();
 
-		registerCommands(new DefaultCommands(this));
+		if(help != HelpCommand.none)
+			registerCommands(new DefaultCommands(this, help));
 	}
 
 	/// Boolean whether or not command invocations are allowed in private messages.

--- a/src/diggler/defaultcommands.d
+++ b/src/diggler/defaultcommands.d
@@ -11,10 +11,12 @@ final class DefaultCommands : ICommandSet
 	Context _context;
 	alias _context this;
 	Command helpCommand;
+	Bot.HelpCommand helpConfig;
 
-	this(Bot bot)
+	this(Bot bot, Bot.HelpCommand helpConfig)
 	{
 		this.bot = bot;
+		this.helpConfig = helpConfig;
 		this.helpCommand = Command.create!help(&help);
 	}
 
@@ -22,35 +24,46 @@ final class DefaultCommands : ICommandSet
 	void help(string commandName = null)
 	{
 		import std.array;
-		import std.algorithm : filter, map, joiner, reduce;
+		import std.algorithm : filter, map, joiner, reduce, sort;
 		import std.range : chain;
 		import irc.util : values;
 		import diggler.util : pluralize;
 
 		if(commandName.empty)
 		{
-			auto namedSets = bot.commandSets.filter!(set => set.category);
-
-			foreach(cmdSet; namedSets)
+			if(helpConfig == Bot.HelpCommand.simple)
 			{
-				string[] commands = cmdSet.commandNames;
-				if(!commands.empty)
-				{
-					auto commandList = commands.joiner(", ");
-					reply(`%s %s %s: %s`, commands.length, cmdSet.category, pluralize!"command"(commands.length), commandList);
-				}
+				import std.experimental.allocator : makeArray;
+				import std.experimental.allocator.mallocator : Mallocator;
+				import std.experimental.allocator.showcase : StackFront;
+				StackFront!(2048, Mallocator) alloc;
+				reply("Commands: %s", alloc.makeArray!string(bot.commandSets.map!(set => set.commandNames).joiner).sort().joiner(", "));
 			}
-
-			auto miscCommands = bot.commandSets
-				.filter!(set => !set.category)
-				.map!(set => cast(string[])set.commandNames);
-
-			auto numCommands = reduce!((sum, cmds) => sum + cmds.length)(0UL, miscCommands);
-
-			if(numCommands != 0)
+			else
 			{
-				auto disambiguation = namedSets.empty? "" : "miscellaneous ";
-				reply("%s %s%s: %s", numCommands, disambiguation, pluralize!"command"(numCommands), miscCommands.joiner().joiner(", "));
+				auto namedSets = bot.commandSets.filter!(set => set.category);
+
+				foreach(cmdSet; namedSets)
+				{
+					string[] commands = cmdSet.commandNames;
+					if(!commands.empty)
+					{
+						auto commandList = commands.joiner(", ");
+						reply(`%s %s %s: %s`, commands.length, cmdSet.category, pluralize!"command"(commands.length), commandList);
+					}
+				}
+
+				auto miscCommands = bot.commandSets
+					.filter!(set => !set.category)
+					.map!(set => cast(string[])set.commandNames);
+
+				auto numCommands = reduce!((sum, cmds) => sum + cmds.length)(0UL, miscCommands);
+
+				if(numCommands != 0)
+				{
+					auto disambiguation = namedSets.empty? "" : "miscellaneous ";
+					reply("%s %s%s: %s", numCommands, disambiguation, pluralize!"command"(numCommands), miscCommands.joiner().joiner(", "));
+				}
 			}
 		}
 		else


### PR DESCRIPTION
Added simple enum to bot.d allowing:
- Disabling of default command set (removal of the help function)
- Simple output for the help function (single-line, no command set names)
- Categorical output for the help function (the current output)

Disabling of the default set will allow users to define their own custom help function in another command set

Example usage:

``` d
import diggler.bot;

void main()
{
        Bot bot = new Bot(Bot.Configuration("testbot",  "dlang", "Diggler", "!"), HelpCommand.none);
        bot.registerCommands(new MyCommands);
        auto client = bot.connect("irc://irc.freenode.org/testbot");
        client.onNickInUse ~= nick => nick ~ "_";
        bot.run();
}

class MyCommands : CommandSet!MyCommands {
        mixin CommandContext!();
        void help(){
                reply("My custom help function");
        }
}
```
