### PR TITLE
Added identified attribute

### DIFF
--- a/src/diggler/attribute.d
+++ b/src/diggler/attribute.d
@@ -58,6 +58,15 @@ struct admin {}
 /**
  * Command attribute.
  *
+ * Methods with this attribute can only be called by a user
+ * that is registered with services, meaning they are the
+ * owner of that particular nickname.
+ */
+struct identified {}
+
+/**
+ * Command attribute.
+ *
  * Commands for command methods with attribute cannot be
  * invoked in private messages, regardless of the
  * value of the $(DPREF bot, Bot.allowPMCommands) property.

--- a/src/diggler/command.d
+++ b/src/diggler/command.d
@@ -96,6 +96,7 @@ struct Command
 
 	ParameterInfo[] parameterInfo;
 	bool adminOnly = false;
+	bool identifiedOnly = false;
 	bool channelOnly = false;
 	bool variadic = false;
 
@@ -213,6 +214,9 @@ struct Command
 
 		static if(hasAttribute!(handler, .admin))
 			cmd.adminOnly = true;
+
+		static if(hasAttribute!(handler, .identified))
+			cmd.identifiedOnly = true;
 
 		static if(hasAttribute!(handler, .channelOnly))
 			cmd.channelOnly = true;

--- a/src/diggler/defaultcommands.d
+++ b/src/diggler/defaultcommands.d
@@ -25,7 +25,8 @@ final class DefaultCommands : ICommandSet
 	{
 		import std.array;
 		import std.algorithm : filter, map, joiner, reduce, sort;
-		import std.range : chain;
+		import std.range : chain, only, zip;
+		import std.format : format;
 		import irc.util : values;
 		import diggler.util : pluralize;
 
@@ -82,13 +83,14 @@ final class DefaultCommands : ICommandSet
 
 					immutable description = cmd.usage? cmd.usage : "no description available.";
 
+					static immutable flagList = ["channel", "admin", "identified"];
 					string flags;
-					if(cmd.channelOnly && cmd.adminOnly)
-						flags = " [channel, admin]";
-					else if(cmd.channelOnly)
-						flags = " [channel]";
-					else if(cmd.adminOnly)
-						flags = " [admin]";
+					auto list = zip(flagList, only(cmd.channelOnly, cmd.adminOnly, cmd.identifiedOnly))
+							.filter!(t => t[1])
+							.map!(t => t[0]);
+
+					if(!list.empty)
+						flags = format(" [%-(%s, %)]", list);
 					else
 						flags = "";
 

--- a/src/diggler/tracker.d
+++ b/src/diggler/tracker.d
@@ -7,8 +7,9 @@ import irc.tracker;
 struct UserInfo
 {
 	mixin(bitfields!(
-		bool, "isAdmin", 1,
-		ubyte, "padding", 7
+		bool, "isIdentified", 1,
+		bool, "isInvalidated", 1,
+		ubyte, "padding", 6
 	));
 }
 


### PR DESCRIPTION
This pull introduces a new UDA, `@identified`, which causes a command to only be usable by a user that is identified with services. This is useful for commands which need the user to be verified, for example, to avoid impersonation of another user. Additionally, `Context.isAdmin` has been refactored to avoid code duplication with `Context.isIdentified`.
